### PR TITLE
WIP Enable sendToContact API call to define additional cc/bcc recipients

### DIFF
--- a/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
+++ b/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
@@ -124,10 +124,12 @@ class EmailApiController extends CommonApiController
                 return $lead;
             }
 
-            $post       = $this->request->request->all();
-            $tokens     = (!empty($post['tokens'])) ? $post['tokens'] : [];
-            $assetsIds  = (!empty($post['assetAttachments'])) ? $post['assetAttachments'] : [];
-            $response   = ['success' => false];
+            $post          = $this->request->request->all();
+            $tokens        = (!empty($post['tokens'])) ? $post['tokens'] : [];
+            $assetsIds     = (!empty($post['assetAttachments'])) ? $post['assetAttachments'] : [];
+            $ccRecipients  = (!empty($post['ccRecipients'])) ? $post['ccRecipients'] : [];
+            $bccRecipients = (!empty($post['bccRecipients'])) ? $post['bccRecipients'] : [];
+            $response      = ['success' => false];
 
             $cleanTokens = [];
 
@@ -149,6 +151,8 @@ class EmailApiController extends CommonApiController
                     'source'            => ['api', 0],
                     'tokens'            => $cleanTokens,
                     'assetAttachments'  => $assetsIds,
+                    'ccRecipients'      => $ccRecipients,
+                    'bccRecipients'     => $bccRecipients,
                     'return_errors'     => true,
                 ]
             );

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1347,10 +1347,12 @@ class MailHelper
      * @param array $slots               Slots configured in theme
      * @param array $assetAttachments    Assets to send
      * @param bool  $ignoreTrackingPixel Do not append tracking pixel HTML
+     * @param array $ccRecipients        array of additional cc recipients
+     * @param array $bccRecipients       array of additional bcc recipients
      *
      * @return bool Returns false if there were errors with the email configuration
      */
-    public function setEmail(Email $email, $allowBcc = true, $slots = [], $assetAttachments = [], $ignoreTrackingPixel = false)
+    public function setEmail(Email $email, $allowBcc = true, $slots = [], $assetAttachments = [], $ignoreTrackingPixel = false, $ccRecipients = [], $bccRecipients = [])
     {
         $this->email = $email;
 
@@ -1385,11 +1387,23 @@ class MailHelper
             $this->setReplyTo($addresses[0]);
         }
 
+        if ($ccRecipients) {
+            foreach ($ccRecipients as $ccAddress => $name) {
+                $this->addCc($ccAddress, $name);
+            }
+        }
+
         if ($allowBcc) {
             $bccAddress = $email->getBccAddress();
             if (!empty($bccAddress)) {
                 $addresses = array_fill_keys(array_map('trim', explode(',', $bccAddress)), null);
                 foreach ($addresses as $bccAddress => $name) {
+                    $this->addBcc($bccAddress, $name);
+                }
+            }
+
+            if ($bccRecipients) {
+                foreach ($bccRecipients as $bccAddress => $name) {
                     $this->addBcc($bccAddress, $name);
                 }
             }

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -1310,6 +1310,8 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
         $ignoreDNC           = ArrayHelper::getValue('ignoreDNC', $options, false);
         $tokens              = ArrayHelper::getValue('tokens', $options, []);
         $assetAttachments    = ArrayHelper::getValue('assetAttachments', $options, []);
+        $ccRecipients        = ArrayHelper::getValue('ccRecipients', $options, []);
+        $bccRecipients       = ArrayHelper::getValue('bccRecipients', $options, []);
         $customHeaders       = ArrayHelper::getValue('customHeaders', $options, []);
         $emailType           = ArrayHelper::getValue('email_type', $options, '');
         $isMarketing         = (in_array($emailType, ['marketing']) || !empty($listId));
@@ -1456,7 +1458,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
             foreach ($translatedEmails as $translatedId => $contacts) {
                 $emailEntity = ($translatedId === $parentId) ? $useSettings['entity'] : $useSettings['translations'][$translatedId];
 
-                $this->sendModel->setEmail($emailEntity, $channel, $customHeaders, $assetAttachments, $useSettings['slots'])
+                $this->sendModel->setEmail($emailEntity, $channel, $customHeaders, $assetAttachments, $useSettings['slots'], $ccRecipients, $bccRecipients)
                     ->setListId($listId);
 
                 foreach ($contacts as $contact) {

--- a/app/bundles/EmailBundle/Model/SendEmailToContact.php
+++ b/app/bundles/EmailBundle/Model/SendEmailToContact.php
@@ -172,10 +172,12 @@ class SendEmailToContact
      * @param array $channel          ['channelName', 'channelId']
      * @param array $assetAttachments
      * @param array $slots            @deprecated to be removed in 3.0; support for old email template format
+     * @param array $ccRecipients     [[address => name]]
+     * @param array $bccRecipients    [[address => name]]
      *
      * @return $this
      */
-    public function setEmail(Email $email, array $channel = [], array $customHeaders = [], array $assetAttachments = [], array $slots = [])
+    public function setEmail(Email $email, array $channel = [], array $customHeaders = [], array $assetAttachments = [], array $slots = [], $ccRecipients = [], $bccRecipients = [])
     {
         // Flush anything that's pending from a previous email
         $this->flush();
@@ -183,7 +185,7 @@ class SendEmailToContact
         // Enable the queue if applicable to the transport
         $this->mailer->enableQueue();
 
-        if ($this->mailer->setEmail($email, true, $slots, $assetAttachments)) {
+        if ($this->mailer->setEmail($email, true, $slots, $assetAttachments, $ccRecipients, $bccRecipients)) {
             $this->mailer->setSource($channel);
             $this->mailer->setCustomHeaders($customHeaders);
 


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | Y
| Automated tests included? | N
| Related user documentation PR URL | 
| Related developer documentation PR URL | https://github.com/mautic/developer-documentation/pull/141
| Issues addressed (#s or URLs) | 
| BC breaks? | N
| Deprecations? | N

#### Description:
This PR adds the parameters `ccRecipients` ans `bccRecipients` to the sendToContact Email API.
I followed the implementation of `assetAttachments`.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Call the new API paramets like this:
  ```
$params = [
     'tokens' => $tokens,
     'assetAttachments' => $assetAttachments,
     'ccReceiver' => $ccRecipients,
     'bccReceiver' => $bccRecipients,
 ];
$response = $emailApi->sendToContact($mailId, $contactId, $params);
```
